### PR TITLE
Attempt to fix NPM dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,22 +2,23 @@
   "name": "llm-code-format",
   "version": "1.0.0",
   "description": "Parsing and serialization of multiple code files in Markdown for LLMs",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "default": "./dist/cjs/index.js",
-      "types": "./dist/esm/index.d.ts"
+      "default": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "scripts": {
-    "build": "npm run build:esm && npm run build:cjs",
-    "build:esm": "tsc -p tsconfig.json",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build": "npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
     "test": "vitest run",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { parseMarkdownFiles } from "./parseMarkdownFiles.js";
-export { serializeMarkdownFiles } from "./serializeMarkdownFiles.js";
+export { parseMarkdownFiles } from "./parseMarkdownFiles";
+export { serializeMarkdownFiles } from "./serializeMarkdownFiles";
 export {
   StreamingMarkdownParser,
   StreamingParserCallbacks,
-} from "./streamingParser.js";
+} from "./streamingParser";

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,15 +1,7 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
     "module": "CommonJS",
-    "moduleResolution": "node",
-    "declaration": true,
-    "outDir": "./dist/cjs",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+    "outDir": "./dist/cjs"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "ESNext",
     "moduleResolution": "node",
-    "declaration": true,
-    "outDir": "./dist/esm",
     "strict": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "outDir": "./dist",
+    "rootDir": "./src",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Fixes this garbage hopefully:

```
(node:371101) Warning: Failed to load the ES module: /home/curran/repos/vizhub3/node_modules/llm-code-format/dist/esm/index.js. Make sure to set "type": "module" in the nearest package.json file or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
6:53:43 PM [vite] (ssr) Error when evaluating SSR module /src/entry-server.tsx: Unexpected token 'export'
      at wrapSafe (node:internal/modules/cjs/loader:1666:18)
      at Module._compile (node:internal/modules/cjs/loader:1708:20)
      at Object..js (node:internal/modules/cjs/loader:1899:10)
      at Module.load (node:internal/modules/cjs/loader:1469:32)
      at Function._load (node:internal/modules/cjs/loader:1286:12)
      at TracingChannel.traceSync (node:diagnostics_channel:322:14)
      at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
      at cjsLoader (node:internal/modules/esm/translators:315:5)
      at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:207:7)
      at ModuleJob.run (node:internal/modules/esm/module_job:274:25)
/home/curran/repos/vizhub3/node_modules/llm-code-format/dist/esm/index.js:1
export { parseMarkdownFiles } from "./parseMarkdownFiles.js";
^^^^^^

```