### PR TITLE
Second attempt at NPM fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { parseMarkdownFiles } from "./parseMarkdownFiles";
-export { serializeMarkdownFiles } from "./serializeMarkdownFiles";
+export { parseMarkdownFiles } from "./parseMarkdownFiles.js";
+export { serializeMarkdownFiles } from "./serializeMarkdownFiles.js";
 export {
   StreamingMarkdownParser,
   StreamingParserCallbacks,
-} from "./streamingParser";
+} from "./streamingParser.js";

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm"
+  }
+}


### PR DESCRIPTION
More garbage WTF

```
7:09:08 PM [vite] (client) Re-optimizing dependencies because lockfile has changed
Cannot optimize dependency: @uiw/codemirror-themes, present in client 'optimizeDeps.include'
7:09:12 PM [vite] (ssr) Error when evaluating SSR module /src/entry-server.tsx: Cannot find module '/home/curran/repos/vizhub3/node_modules/llm-code-format/dist/esm/parseMarkdownFiles' imported from /home/curran/repos/vizhub3/node_modules/llm-code-format/dist/esm/index.js
      at finalizeResolution (node:internal/modules/esm/resolve:275:11)
      at moduleResolve (node:internal/modules/esm/resolve:860:10)
      at defaultResolve (node:internal/modules/esm/resolve:984:11)
      at nextResolve (node:internal/modules/esm/hooks:748:28)
      at o (file:///home/curran/repos/vizhub3/node_modules/@tailwindcss/node/dist/esm-cache.loader.mjs:1:74)
      at nextResolve (node:internal/modules/esm/hooks:748:28)
      at Hooks.resolve (node:internal/modules/esm/hooks:240:30)
      at MessagePort.handleMessage (node:internal/modules/esm/worker:199:24)
      at [nodejs.internal.kHybridDispatch] (node:internal/event_target:827:20)
      at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)

node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/curran/repos/vizhub3/node_modules/llm-code-format/dist/esm/parseMarkdownFiles' imported from /home/curran/repos/vizhub3/node_modules/llm-code-format/dist/esm/index.js
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)

```