### PR TITLE
Adopt viz-types FileCollection data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ body { color: blue; }
 
 const { files, format } = parseMarkdownFiles(markdownString);
 console.log(format); // "Bold Format"
-console.log(files); // Array of { name, text } objects
+console.log(files); // Object with filenames as keys and contents as values
 
 // Serialize files back to Markdown
-const files = [
-  { name: "index.html", text: "<h1>Hello World</h1>" },
-  { name: "styles.css", text: "body { color: blue; }" },
-];
+const files = {
+  "index.html": "<h1>Hello World</h1>",
+  "styles.css": "body { color: blue; }",
+};
 
 const markdown = serializeMarkdownFiles(files);
 ```
@@ -88,14 +88,14 @@ fs.readdirSync(blogDir)
     // Use llm-code-format to extract code blocks from markdown!
     const { files } = parseMarkdownFiles(markdownString);
 
-    if (!files.length) return;
+    if (Object.keys(files).length === 0) return;
     const outputDirectory = path.join(publicDir, postName);
     if (fs.existsSync(outputDirectory)) {
       fs.rmSync(outputDirectory, { recursive: true });
     }
     fs.mkdirSync(outputDirectory);
-    files.forEach(({ name, text }) => {
-      fs.writeFileSync(path.join(outputDirectory, name), text);
+    Object.entries(files).forEach(([name, content]) => {
+      fs.writeFileSync(path.join(outputDirectory, name), content);
     });
   });
 ```
@@ -106,7 +106,7 @@ fs.readdirSync(blogDir)
 
 Parses a Markdown string containing code blocks and returns an object with:
 
-- `files`: Array of `{ name: string, text: string }` objects
+- `files`: Object with filenames as keys and file contents as values
 - `format`: String indicating the detected format
 
 Optional `format` parameter to specify a particular format to parse:
@@ -121,9 +121,9 @@ Optional `format` parameter to specify a particular format to parse:
 - 'hash'
 - 'numbered-bold'
 
-### serializeMarkdownFiles(files: Array<{ name: string, text: string }>)
+### serializeMarkdownFiles(files: FileCollection)
 
-Converts an array of file objects into a Markdown string using the Bold Format.
+Converts a FileCollection object into a Markdown string using the Bold Format.
 
 ### StreamingMarkdownParser
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
+        "@vizhub/viz-types": "^0.1.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.2",
         "vitest": "^3.1.1"
@@ -845,6 +846,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vizhub/viz-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vizhub/viz-types/-/viz-types-0.1.0.tgz",
+      "integrity": "sha512-g1J3t5WPILUSfM+Pjq/CsSkvQMB5yh9RQmWsIFESq5BEwFK7zR6Zy4h6t5VPTP8iktLyiXtvYOuvDGcUb+LiCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "README.md"
   ],
   "devDependencies": {
+    "@vizhub/viz-types": "^0.1.0",
+    "prettier": "^3.5.3",
     "typescript": "^5.8.2",
-    "vitest": "^3.1.1",
-    "prettier": "^3.5.3"
+    "vitest": "^3.1.1"
   }
 }

--- a/src/parseMarkdownFiles.test.ts
+++ b/src/parseMarkdownFiles.test.ts
@@ -24,11 +24,11 @@ test("parseMarkdownFiles detects Bold Format and parses files", () => {
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Bold Format with extra text and parses files", () => {
@@ -53,11 +53,11 @@ test("parseMarkdownFiles detects Bold Format with extra text and parses files", 
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Backtick-Heading Format and parses files", () => {
@@ -82,11 +82,11 @@ test("parseMarkdownFiles detects Backtick-Heading Format and parses files", () =
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Backtick-Heading Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Standard Heading Format and parses files", () => {
@@ -111,11 +111,11 @@ test("parseMarkdownFiles detects Standard Heading Format and parses files", () =
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Standard Heading Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Colon Format and parses files", () => {
@@ -137,11 +137,11 @@ styles.css:
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Colon Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Bold Format and parses files", () => {
@@ -166,11 +166,11 @@ test("parseMarkdownFiles detects Bold Format and parses files", () => {
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects File Bold Format and parses files", () => {
@@ -195,11 +195,11 @@ test("parseMarkdownFiles detects File Bold Format and parses files", () => {
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("File Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Heading Bold Format and parses files", () => {
@@ -224,11 +224,11 @@ test("parseMarkdownFiles detects Heading Bold Format and parses files", () => {
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Heading Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Numbered Bold Format and parses files", () => {
@@ -248,16 +248,10 @@ This file contains the CSS for styling the scatter plot.
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Numbered Bold Format");
-  expect(files).toEqual([
-    {
-      name: "index.html",
-      text: `<!-- HTML content -->`,
-    },
-    {
-      name: "style.css",
-      text: `/* CSS content */`,
-    },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "style.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Numbered Bold Format with extra text", () => {
@@ -279,16 +273,10 @@ test("parseMarkdownFiles detects Numbered Bold Format with extra text", () => {
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Numbered Bold Format");
-  expect(files).toEqual([
-    {
-      name: "index.html",
-      text: `<!-- HTML content -->`,
-    },
-    {
-      name: "style.css",
-      text: `/* CSS content */`,
-    },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "style.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Numbered Backtick Format and parses files", () => {
@@ -308,16 +296,10 @@ This file contains the CSS for styling the scatter plot.
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Numbered Backtick Format");
-  expect(files).toEqual([
-    {
-      name: "index.html",
-      text: `<!-- HTML content -->`,
-    },
-    {
-      name: "style.css",
-      text: `/* CSS content */`,
-    },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "style.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles detects Hash Format and parses files", () => {
@@ -339,11 +321,11 @@ test("parseMarkdownFiles detects Hash Format and parses files", () => {
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Hash Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 test("parseMarkdownFiles should use final version", () => {
@@ -364,12 +346,9 @@ And then we do some work on it and...
   `;
   const { files, format } = parseMarkdownFiles(markdownString);
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    {
-      name: "index.html",
-      text: "<!-- New HTML content -->",
-    },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- New HTML content -->",
+  });
 });
 
 const content = ` To create a scatter plot with D3.js, follow these steps:
@@ -458,20 +437,14 @@ test("parseMarkdownFiles work with real output from Mistral", () => {
   const { files, format } = parseMarkdownFiles(content);
   // console.log(JSON.stringify(files, null, 2));
   expect(format).toBe("Numbered Bold Format");
-  expect(files).toEqual([
-    {
-      name: "index.html",
-      text: '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="UTF-8">\n  <title>Scatter Plot with D3.js</title>\n  <script src="https://d3js.org/d3.v6.min.js"></script>\n  <link rel="stylesheet" href="styles.css">\n</head>\n<body>\n  <div id="scatter-plot"></div>\n  <script src="index.js"></script>\n</body>\n</html>',
-    },
-    {
-      name: "styles.css",
-      text: "/* styles.css */\nbody, html {\n  height: 102%;\n  padding: 0;\n}\n\n#scatter-plot {\n  width: 100%;\n  height: 100%;\n}",
-    },
-    {
-      name: "index.js",
-      text: '// index.js\n\nd3.select("body")\n  .append("div")\n  .attr("id", "scatter-plot");\n\n// Load data\nconst data = d3.randomN(500, (x, y) => ({x, y}));\n\n// Create SVG container\nconst svg = d3.select("#scatter-plot")\n  .append("svg")\n  .attr("width", "100%")\n  .attr("height", "100%");\n\n// Scales X and Y axes\nconst xInfo = d3.scaleLinear()\n  .domain(d3.extent(data, d => d.x))\n  .range([0, svg.node().width]);\nconst yInfo = d3.scaleLinear()\n  .domain(d3.extent(data, d => d.y))\n  .range([svg.node().height, 0]);\n\n// Create circles and color them based on their distances from the axes\nsvg.selectAll("circle")\n  .data(data)\n  .enter()\n  .append("circle")\n  .attr("cx", d => xInfo(d.x))\n  .attr("cy", d => yInfo(d.y))\n  .attr("r", 4)\n  .attr("fill", "steelblue")\n  .on("mousemove", function(event, d) {\n    // Change color of circles based on their distances from the axes\n    const xDistance = Math.abs(data.average(d => d.x) - d3.mouse(this).x);\n    const yDistance = Math.abs(data.average(d => d.y) - d3.mouse(this).y);\n    d3.select(this)\n      .style("fill", `steelblue${yDistance > xDistance ? "20%" : ""}`);\n  });',
-    },
-  ]);
+  expect(files).toEqual({
+    "index.html":
+      '<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="UTF-8">\n  <title>Scatter Plot with D3.js</title>\n  <script src="https://d3js.org/d3.v6.min.js"></script>\n  <link rel="stylesheet" href="styles.css">\n</head>\n<body>\n  <div id="scatter-plot"></div>\n  <script src="index.js"></script>\n</body>\n</html>',
+    "styles.css":
+      "/* styles.css */\nbody, html {\n  height: 102%;\n  padding: 0;\n}\n\n#scatter-plot {\n  width: 100%;\n  height: 100%;\n}",
+    "index.js":
+      '// index.js\n\nd3.select("body")\n  .append("div")\n  .attr("id", "scatter-plot");\n\n// Load data\nconst data = d3.randomN(500, (x, y) => ({x, y}));\n\n// Create SVG container\nconst svg = d3.select("#scatter-plot")\n  .append("svg")\n  .attr("width", "100%")\n  .attr("height", "100%");\n\n// Scales X and Y axes\nconst xInfo = d3.scaleLinear()\n  .domain(d3.extent(data, d => d.x))\n  .range([0, svg.node().width]);\nconst yInfo = d3.scaleLinear()\n  .domain(d3.extent(data, d => d.y))\n  .range([svg.node().height, 0]);\n\n// Create circles and color them based on their distances from the axes\nsvg.selectAll("circle")\n  .data(data)\n  .enter()\n  .append("circle")\n  .attr("cx", d => xInfo(d.x))\n  .attr("cy", d => yInfo(d.y))\n  .attr("r", 4)\n  .attr("fill", "steelblue")\n  .on("mousemove", function(event, d) {\n    // Change color of circles based on their distances from the axes\n    const xDistance = Math.abs(data.average(d => d.x) - d3.mouse(this).x);\n    const yDistance = Math.abs(data.average(d => d.y) - d3.mouse(this).y);\n    d3.select(this)\n      .style("fill", `steelblue${yDistance > xDistance ? "20%" : ""}`);\n  });',
+  });
 });
 
 // Test that parses correctly when the format is 'bold' and the input matches 'Bold Format'
@@ -497,11 +470,11 @@ test("parseMarkdownFiles parses Bold Format when format is specified as 'bold'",
   `;
   const { files, format } = parseMarkdownFiles(markdownString, "bold");
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  });
 });
 
 // Test that returns empty files when format is 'bold' but the input does not match 'Bold Format'
@@ -527,7 +500,7 @@ test("parseMarkdownFiles returns empty files when format is 'bold' but input doe
   `;
   const { files, format } = parseMarkdownFiles(markdownString, "bold");
   expect(format).toBe("Unknown Format");
-  expect(files).toEqual([]);
+  expect(files).toEqual({});
 });
 
 // Test that throws an error when an unsupported format is specified
@@ -561,12 +534,9 @@ test("parseMarkdownFiles handles duplicate file names in Bold Format when format
   `;
   const { files, format } = parseMarkdownFiles(markdownString, "bold");
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    {
-      name: "index.html",
-      text: "<!-- New HTML content -->",
-    },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- New HTML content -->",
+  });
 });
 
 // Test that parses correctly when additional text is present between code blocks in Bold Format
@@ -588,8 +558,8 @@ Some additional description or instructions.
   `;
   const { files, format } = parseMarkdownFiles(markdownString, "bold");
   expect(format).toBe("Bold Format");
-  expect(files).toEqual([
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-  ]);
+  expect(files).toEqual({
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+  });
 });

--- a/src/parseMarkdownFiles.ts
+++ b/src/parseMarkdownFiles.ts
@@ -1,6 +1,11 @@
 // parseMarkdownFiles.ts
-export function parseMarkdownFiles(markdownString: string, format?: string) {
-  const files = [];
+import { FileCollection } from "@vizhub/viz-types";
+
+export function parseMarkdownFiles(
+  markdownString: string,
+  format?: string,
+): { files: FileCollection; format: string } {
+  const files: FileCollection = {};
 
   const backtickHeadingRegex =
     /^\s*###\s*`([^`]+)`\s*\n```(?:\w+)?\n([\s\S]*?)```/gm;
@@ -85,17 +90,17 @@ export function parseMarkdownFiles(markdownString: string, format?: string) {
   // Process each format and stop after the first matching format
   for (const { regex, format: fmt } of selectedRegexes) {
     regex.lastIndex = 0; // Reset regex index
-    const matches: Record<string, { name: string; text: string }> = {};
+    const matches: Record<string, string> = {};
     let match;
 
     while ((match = regex.exec(markdownString)) !== null) {
       const name = match[1].trim();
       const code = match[2].trim();
-      matches[name] = { name, text: code };
+      matches[name] = code;
     }
 
     if (Object.keys(matches).length > 0) {
-      files.push(...Object.values(matches));
+      Object.assign(files, matches);
       detectedFormat = fmt;
       break; // Stop after the first matching format
     }

--- a/src/serializeMarkdownFiles.test.ts
+++ b/src/serializeMarkdownFiles.test.ts
@@ -5,11 +5,11 @@ import { serializeMarkdownFiles } from "./serializeMarkdownFiles";
 // Tests for parseMarkdownFiles function with different formats
 
 test("serializeMarkdownFiles outputs bold format", () => {
-  const files = [
-    { name: "index.html", text: "<!-- HTML content -->" },
-    { name: "script.js", text: "// JavaScript content" },
-    { name: "styles.css", text: "/* CSS content */" },
-  ];
+  const files = {
+    "index.html": "<!-- HTML content -->",
+    "script.js": "// JavaScript content",
+    "styles.css": "/* CSS content */",
+  };
   const markdownString = serializeMarkdownFiles(files);
 
   expect(markdownString).toBe(`**index.html**

--- a/src/serializeMarkdownFiles.ts
+++ b/src/serializeMarkdownFiles.ts
@@ -5,11 +5,11 @@ const language = (name: string) => {
   return "";
 };
 
-export const serializeMarkdownFiles = (
-  files: Array<{ name: string; text: string }>,
-) =>
-  files
-    .map(({ name, text }) =>
+import { FileCollection } from "@vizhub/viz-types";
+
+export const serializeMarkdownFiles = (files: FileCollection) =>
+  Object.entries(files)
+    .map(([name, text]) =>
       [`**${name}**\n`, "```" + language(name), text, "```\n"].join("\n"),
     )
     .join("\n")


### PR DESCRIPTION
Major breaking change: the format for working with files is now an object, not an array.

The point of this is to harmonize the types across the VizHub open source ecosystem based on https://www.npmjs.com/package/@vizhub/viz-types