### PR TITLE
Rename format function from `serializeMarkdownFiles` to `formatMarkdownFiles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install llm-code-format
 ### Basic Example Usage
 
 ```typescript
-import { parseMarkdownFiles, serializeMarkdownFiles } from "llm-code-format";
+import { parseMarkdownFiles, formatMarkdownFiles } from "llm-code-format";
 
 // Parse Markdown content containing code blocks
 const markdownString = `
@@ -64,7 +64,7 @@ const files = {
   "styles.css": "body { color: blue; }",
 };
 
-const markdown = serializeMarkdownFiles(files);
+const markdown = formatMarkdownFiles(files);
 ```
 
 ### Recipe: Extract Files from Blog Posts
@@ -123,7 +123,7 @@ Optional `format` parameter to specify a particular format to parse:
 - 'hash'
 - 'numbered-bold'
 
-### serializeMarkdownFiles(files: FileCollection)
+### formatMarkdownFiles(files: FileCollection)
 
 Converts a FileCollection object into a Markdown string using the Bold Format.
 

--- a/src/formatMarkdownFiles.test.ts
+++ b/src/formatMarkdownFiles.test.ts
@@ -1,16 +1,16 @@
 // parseMarkdownFiles.test.js
 import { expect, test } from "vitest";
-import { serializeMarkdownFiles } from "./serializeMarkdownFiles";
+import { formatMarkdownFiles } from "./formatMarkdownFiles";
 
 // Tests for parseMarkdownFiles function with different formats
 
-test("serializeMarkdownFiles outputs bold format", () => {
+test("formatMarkdownFiles outputs bold format", () => {
   const files = {
     "index.html": "<!-- HTML content -->",
     "script.js": "// JavaScript content",
     "styles.css": "/* CSS content */",
   };
-  const markdownString = serializeMarkdownFiles(files);
+  const markdownString = formatMarkdownFiles(files);
 
   expect(markdownString).toBe(`**index.html**
 

--- a/src/formatMarkdownFiles.ts
+++ b/src/formatMarkdownFiles.ts
@@ -7,7 +7,7 @@ const language = (name: string) => {
 
 import { FileCollection } from "@vizhub/viz-types";
 
-export const serializeMarkdownFiles = (files: FileCollection) =>
+export const formatMarkdownFiles = (files: FileCollection) =>
   Object.entries(files)
     .map(([name, text]) =>
       [`**${name}**\n`, "```" + language(name), text, "```\n"].join("\n"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { parseMarkdownFiles } from "./parseMarkdownFiles.js";
-export { serializeMarkdownFiles } from "./serializeMarkdownFiles.js";
+export { formatMarkdownFiles } from "./formatMarkdownFiles.js";
 export {
   StreamingMarkdownParser,
   StreamingParserCallbacks,


### PR DESCRIPTION
Fix #3